### PR TITLE
(fix): use JUnit 5 instead of JUnit 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
 

--- a/src/test/java/edu/austral/ingsis/math/ListVariablesTest.java
+++ b/src/test/java/edu/austral/ingsis/math/ListVariablesTest.java
@@ -1,12 +1,13 @@
 package edu.austral.ingsis.math;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
 
 public class ListVariablesTest {
 

--- a/src/test/java/edu/austral/ingsis/math/PrintTest.java
+++ b/src/test/java/edu/austral/ingsis/math/PrintTest.java
@@ -1,9 +1,9 @@
 package edu.austral.ingsis.math;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PrintTest {
 

--- a/src/test/java/edu/austral/ingsis/math/ResolutionTest.java
+++ b/src/test/java/edu/austral/ingsis/math/ResolutionTest.java
@@ -1,9 +1,9 @@
 package edu.austral.ingsis.math;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 
 public class ResolutionTest {
 

--- a/src/test/java/edu/austral/ingsis/math/ResolutionWithVariablesTest.java
+++ b/src/test/java/edu/austral/ingsis/math/ResolutionWithVariablesTest.java
@@ -1,9 +1,9 @@
 package edu.austral.ingsis.math;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 
 public class ResolutionWithVariablesTest {
 


### PR DESCRIPTION
## Why?

When trying to run tests with Gradle, a JUnit error pops up and tests are never run. I suspect this has to do with the `useJUnitPlatform` clause and the `junit:4` dependency.

## Fix

Use JUnit 5

## StackTrace

```
org.gradle.api.internal.tasks.testing.TestSuiteExecutionException: Could not start Gradle Test Executor 2.
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.startProcessing(SuiteTestClassProcessor.java:44)
	at java.base@17.0.6/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@17.0.6/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base@17.0.6/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.6/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy2/jdk.proxy2.$Proxy5.startProcessing(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$1.run(TestWorker.java:161)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: org.junit.platform.commons.PreconditionViolationException: Cannot create Launcher without at least one TestEngine; consider adding an engine implementation JAR to the classpath
	at app//org.junit.platform.commons.util.Preconditions.condition(Preconditions.java:296)
	at app//org.junit.platform.launcher.core.DefaultLauncher.<init>(DefaultLauncher.java:55)
	at app//org.junit.platform.launcher.core.LauncherFactory.createDefaultLauncher(LauncherFactory.java:134)
	at app//org.junit.platform.launcher.core.LauncherFactory.openSession(LauncherFactory.java:98)
	at app//org.junit.platform.launcher.core.LauncherFactory.openSession(LauncherFactory.java:82)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$BackwardsCompatibleLauncherSession.open(JUnitPlatformTestClassProcessor.java:318)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.createTestExecutor(JUnitPlatformTestClassProcessor.java:81)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.startProcessing(AbstractJUnitTestClassProcessor.java:50)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.startProcessing(SuiteTestClassProcessor.java:42)
	... 18 more
```